### PR TITLE
#166874216  Agent should only be able to update properties posted by him

### DIFF
--- a/API/v1/controller/user.controller.js
+++ b/API/v1/controller/user.controller.js
@@ -25,7 +25,7 @@ class UserController {
     const userCredentials = req.body;
     const result = loginUser(userCredentials);
     if (result) {
-      return res.status(201).json({
+      return res.status(200).json({
         status: 'success',
         data: result,
       });

--- a/API/v1/helper/helper.js
+++ b/API/v1/helper/helper.js
@@ -69,6 +69,12 @@ class Helper {
     const resultingArray = properties.properties.find(el => el.id === id);
     return resultingArray;
   }
+
+  static compareAgents(req, id) {
+    const owner = properties.properties.find(el => el.id === id);
+    if (owner.owner === req.decoded.user.id) return true;
+    return false;
+  }
 }
 
 export default Helper;

--- a/API/v1/middleware/validation.js
+++ b/API/v1/middleware/validation.js
@@ -7,7 +7,7 @@ import propertyData from '../data/property.data';
 
 const {
   trimmer, checkIfEmailExists, checkState,
-  checkLGA, deleteUploadedFile, checkId,
+  checkLGA, deleteUploadedFile, checkId, compareAgents,
 } = Helper;
 
 class Validation {
@@ -127,6 +127,16 @@ class Validation {
       return res.status(404).json({
         status: 404,
         error: 'User with the id not found',
+      });
+    }
+    return next();
+  }
+
+  static compareAgentsByEmail(req, res, next) {
+    if (!compareAgents(req, parseInt(req.params.id, 10))) {
+      return res.status(403).json({
+        status: 403,
+        error: 'You are not authorized to view this resource',
       });
     }
     return next();

--- a/API/v1/routes/property.js
+++ b/API/v1/routes/property.js
@@ -9,7 +9,7 @@ const { postAProperty, updateProperty } = PropertyController;
 const {
   checkForEmptyPropertyPostParameters,
   validateCreatePropertyInput, uploadAnImage, checkAgentId,
-  checkForInvalidRequestParameters, checkForInvalidUpdateParameters,
+  checkForInvalidRequestParameters, checkForInvalidUpdateParameters, compareAgentsByEmail,
 } = Validation;
 
 const { authenticateUser } = AuthenticateUser;
@@ -20,7 +20,7 @@ router.post('/', authenticateUser, uploadAnImage,
   checkForEmptyPropertyPostParameters,
   validateCreatePropertyInput, postAProperty);
 
-router.patch('/:id', authenticateUser, checkAgentId,
+router.patch('/:id', authenticateUser, checkAgentId, compareAgentsByEmail,
   uploadAnImage, checkForInvalidRequestParameters, checkForInvalidUpdateParameters, updateProperty);
 
 export default router;

--- a/API/v1/test/property.test.js
+++ b/API/v1/test/property.test.js
@@ -503,7 +503,7 @@ describe('Test suite for all property related endpoints', () => {
           done();
         });
     });
-    it('Should return an error if the agent adds the address keybut doesn\'t include an address', (done) => {
+    it('Should return an error if the agent adds the address key but doesn\'t include an address', (done) => {
       const id = 1;
       chai
         .request(app)
@@ -520,6 +520,26 @@ describe('Test suite for all property related endpoints', () => {
           expect(res).to.have.status(400);
           expect(res.body.status).to.be.equal(400);
           expect(res.body.error).to.be.equal('address cannot be left empty');
+          done();
+        });
+    });
+    it('Should return an error if the agent wants to update the details of another agent\'s property', (done) => {
+      const id = 6;
+      chai
+        .request(app)
+        .patch(`/api/v1/property/${id}`)
+        .set('x-access-token', adminToken)
+        .set('enctype', 'multipart/formdata')
+        .type('form')
+        .field('state', 'Lagos State')
+        .field('city', 'Alimosho')
+        .field('price', 60000000.50)
+        .field('address', '67, Bambgoye close')
+        .field('type', 'Land')
+        .end((err, res) => {
+          expect(res).to.have.status(403);
+          expect(res.body.status).to.be.equal(403);
+          expect(res.body.error).to.be.equal('You are not authorized to view this resource');
           done();
         });
     });

--- a/API/v1/test/user.test.js
+++ b/API/v1/test/user.test.js
@@ -297,7 +297,7 @@ describe('Tests for all Auth(signup and signin) Endpoints', () => {
           password: 'somepassword',
         })
         .end((err, res) => {
-          expect(res).to.have.status(201);
+          expect(res).to.have.status(200);
           expect(res.body.status).to.be.equal('success');
           expect(res.body.data).to.have.key('token', 'id', 'firstName', 'lastName', 'email', 'isAdmin');
           expect(res.body.data.token).to.be.a('string');


### PR DESCRIPTION
#### What does this PR do?
 Fixes the anomaly that allows an agent to update any property
#### Description of Task to be completed?
 An agent should only be able to update properties posted by him
#### How should this be manually tested?
https://propertypro.herokuapp.com/api/v1/property/:id
#### Any background context you want to provide?
N/A
#### What are the relevant pivotal tracker stories?
[https://www.pivotaltracker.com/story/show/166874216](https://www.pivotaltracker.com/story/show/166874216)
#### Screenshots (if appropriate)
N/A
#### Questions:
N/A
