### PR TITLE
#167206671 Fixes The User Signup Bug

### DIFF
--- a/API/v1/helper/error.js
+++ b/API/v1/helper/error.js
@@ -219,29 +219,25 @@ class ErrorMessages {
    */
   static serverErrorMessage(err, res) {
     let statusCode;
+    let error;
+    statusCode = 500;
+    error = 'Internal Server Error';
     if (err.message === 'Authorization failed. Email or password incorrect') {
+      error = err.message;
       statusCode = 401;
-      return res.status(statusCode).json({
-        status: statusCode,
-        error: err.message,
-      });
     }
     if (err.message === 'Property with the provided id not found') {
+      error = err.message;
       statusCode = 404;
-      return res.status(statusCode).json({
-        status: statusCode,
-        error: err.message,
-      });
+    }
+    if (err.message === 'Email already exists') {
+      error = err.message;
+      statusCode = 409;
     }
     if (err.message === 'You are not permitted to view this resource') {
       statusCode = 403;
-      return res.status(statusCode).json({
-        status: statusCode,
-        error: err.message,
-      });
+      error = err.message;
     }
-    statusCode = 500;
-    const error = 'Internal Server Error';
     return res.status(statusCode).json({
       status: statusCode,
       error,

--- a/API/v1/routes/auth.db.js
+++ b/API/v1/routes/auth.db.js
@@ -1,7 +1,7 @@
 import express from 'express';
 import UserController from '../controller/user.controller.db';
 import Validation from '../middleware/validation';
-import checkExixtingEmail from '../middleware/checkExistingemail';
+import checkExistingEmail from '../middleware/checkExistingemail';
 
 const router = express.Router();
 
@@ -16,7 +16,7 @@ const {
 router.post('/signup',
   checkForEmptyRequestParameters,
   validateSignUpInput,
-  checkExixtingEmail,
+  checkExistingEmail,
   createUser);
 
 router.post('/signin',

--- a/API/v1/test/user.test.js
+++ b/API/v1/test/user.test.js
@@ -329,6 +329,26 @@ describe('Tests for all Auth(signup and signin) Endpoints', () => {
           done();
         });
     });
+    it('Should return an error if the user puts in an email that already exists ', (done) => {
+      chai
+        .request(app)
+        .post('/api/v1/auth/signup')
+        .send({
+          email: 'fergusoniyara@gmail.com',
+          firstName: 'zinedine',
+          lastName: 'zidane',
+          password: 'manforthejob',
+          phoneNumber: '07057154467',
+          address: '90, Herder\'s Ranch, Kafanchan, Kaduna',
+          type: 'agent',
+        })
+        .end((err, res) => {
+          expect(res).to.have.status(409);
+          expect(res.body.status).to.be.equal(409);
+          expect(res.body.error).to.be.equal('Email already exists');
+          done();
+        });
+    });
   });
   describe('POST api/v2/auth/signup', () => {
     it('Should successfully sign up a user and return a token', (done) => {


### PR DESCRIPTION
#### What does this PR do?
Fixes the user signup bug, when a user puts in an email that already exists, the user will get a 409 response informing him that the email he specified has been chosen
#### Description of Task to be completed?
Fix the User signup Anomaly whereby a user gets a 500 error response when he puts in an email that exists already in the database.
#### How should this be manually tested?
Make an http POST request to the link below
https://propertypro.herokuapp.com/api/v1/auth/signup
in the body of the request, add an email that you have created before, if you haven't create one.
When you submit the second time, you should get a 409 error response, informing you that the email already exists.
#### Any background context you want to provide?
N/A
#### What are the relevant pivotal tracker stories?
[https://www.pivotaltracker.com/story/show/167206671](https://www.pivotaltracker.com/story/show/167206671)
#### Screenshots (if appropriate)
N/A
#### Questions:
N/A